### PR TITLE
Change usage model of build.sh

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -33,11 +33,11 @@ function build_busybox()
 	echo "== Build Busybox =="
 	rm -rf $TOP/obj/busybox-$ARCH
 	cd $TOP/$BUSYBOX_DIR
-	mkdir -pv ../obj/busybox-$ARCH
+	mkdir -pv $TOP/obj/busybox-$ARCH
 	cp $TOP/config/$BUSYBOX_CONFIG ./.config
-	make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE O=../obj/busybox-$ARCH oldconfig
+	make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE O=$TOP/obj/busybox-$ARCH oldconfig
 	make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE mrproper
-	cd ../obj/busybox-$ARCH
+	cd $TOP/obj/busybox-$ARCH
 	make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE -j6
 	make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE install
 	cd -
@@ -77,9 +77,9 @@ function build_linux_5_6()
 	cd $TOP/$LINUX_DIR
 	make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE distclean
 	cp $TOP/config/$LINUX_CONFIG arch/$ARCH/configs/my_defconfig
-	make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE O=../obj/linux-$ARCH my_defconfig
-	make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE O=../obj/linux-$ARCH -j6
-	if [ ! -f ../obj/linux-$ARCH/vmlinux ]
+	make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE O=$TOP/obj/linux-$ARCH my_defconfig
+	make ARCH=$ARCH CROSS_COMPILE=$CROSS_COMPILE O=$TOP/obj/linux-$ARCH -j6
+	if [ ! -f $TOP/obj/linux-$ARCH/vmlinux ]
 	then
 		echo "Error: Failed to build Linux"
 		exit 1

--- a/script/build.sh
+++ b/script/build.sh
@@ -12,8 +12,12 @@ BUSYBOX_CONFIG=config-busybox-$BUSYBOX_VER-$ARCH-min
 LINUX_CONFIG=config-linux-$LINUX_VER-$ARCH-initrd
 LINUX_CONFIG=config-linux-$LINUX_VER-$ARCH-initramfs-d05261647
 
-BUSYBOX_DIR=busybox-$BUSYBOX_VER
-LINUX_DIR=linux-$LINUX_VER
+if [ -z $BUSYBOX_DIR ]; then
+	BUSYBOX_DIR=busybox-$BUSYBOX_VER
+fi
+if [ -z $LINUX_DIR ]; then
+	LINUX_DIR=linux-$LINUX_VER
+fi
 INITRAMFS_DIR=obj/initramfs/$ARCH
 BBL_DIR=obj/bbl
 
@@ -127,13 +131,13 @@ fi
 
 if [ ! -d $LINUX_DIR ]
 then
-	echo "Linux source not found"
+	echo "Linux source $LINUX_DIR not found"
 	exit 1
 fi
 
 if [ ! -d $BUSYBOX_DIR ]
 then
-	echo "Busybox source not found"
+	echo "Busybox source $BUSYBOX_DIR not found"
 	exit 1
 fi
 


### PR DESCRIPTION
This patchset changes the usage model of build.sh to allow
1. run build.sh from tiny-linux directory
2. allow users to specify LINUX_DIR/BUSYBOX_DIR via environments.
Please review.